### PR TITLE
grayscale.css

### DIFF
--- a/css/grayscale.css
+++ b/css/grayscale.css
@@ -7,7 +7,7 @@
 body {
     width: 100%;
     height: 100%;
-    font-family: Lora,"Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;
     color: #fff;
     background-color: #000;
 }


### PR DESCRIPTION
Removed Lora from the font-family in the css file.
